### PR TITLE
Disable tensorflow graph optimisation to speedup inference

### DIFF
--- a/bin/hhBtagTest.cc
+++ b/bin/hhBtagTest.cc
@@ -1,4 +1,8 @@
 #include <map>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <vector>
 #include "../interface/HH_BTag.h"
 
 int main(int argc, char *argv[])

--- a/interface/HH_BTag.h
+++ b/interface/HH_BTag.h
@@ -1,7 +1,13 @@
 #include <vector>
 #include <string>
-#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include <memory>
+#include <array>
 
+// Forward-declare to avoid JIT of tensorflow header
+namespace tensorflow {
+    class Session;
+    class MetaGraphDef;
+}
 namespace hh_btag{
 
 namespace InputVars{

--- a/src/HH_BTag.cpp
+++ b/src/HH_BTag.cpp
@@ -1,10 +1,40 @@
 #include "../interface/HH_BTag.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
+
+#include "tensorflow/core/protobuf/rewriter_config.pb.h"
+using tensorflow::RewriterConfig;
 namespace hh_btag{
 
 HH_BTag::HH_BTag(const std::array<std::string, HH_BTag::n_models>& models)
 {
     tensorflow::Options default_options{};
+    // Tensorflow optimizations are run everytime tensorflow::run is called, so it is actually faster to disable them entirely
+    // To study : maybe some of them are beneficial
+    // Another option to study is check "frozen graph" loading mode (loadGraphDef instead of loadMetaGraphDef)
+    // Disable Grappler optimizations. from https://github.com/tensorflow/tensorflow/blob/181a9a13e629ed545ace9e154310c8706ab202e7/tensorflow/core/grappler/clusters/cluster.cc#L82
+    auto rewriter_config =
+        default_options._options.config.mutable_graph_options()->mutable_rewrite_options();
+    rewriter_config->set_layout_optimizer(RewriterConfig::OFF);
+    rewriter_config->set_disable_model_pruning(true);
+    rewriter_config->set_function_optimization(RewriterConfig::OFF);
+    rewriter_config->set_arithmetic_optimization(RewriterConfig::OFF);
+    rewriter_config->set_loop_optimization(RewriterConfig::OFF);
+    rewriter_config->set_dependency_optimization(RewriterConfig::OFF);
+    rewriter_config->set_constant_folding(RewriterConfig::OFF);
+    rewriter_config->set_memory_optimization(RewriterConfig::NO_MEM_OPT);
+    rewriter_config->set_shape_optimization(RewriterConfig::OFF);
+    rewriter_config->set_remapping(RewriterConfig::OFF);
+
+    rewriter_config->set_common_subgraph_elimination(RewriterConfig::OFF); // added
+
+    rewriter_config->set_pin_to_host_optimization(RewriterConfig::OFF);
+    rewriter_config->mutable_auto_parallel()->set_enable(false);
+    rewriter_config->clear_optimizers();
+
+    //          rewrite_cfg.common_subgraph_elimination() != RewriterConfig::OFF ||
+
+
     for(size_t n = 0; n < HH_BTag::n_models; ++n) {
         nn_descs.at(n).graph.reset(tensorflow::loadMetaGraphDef(models.at(n)));
         nn_descs.at(n).session = tensorflow::createSession(nn_descs.at(n).graph.get(), models.at(n), default_options);


### PR DESCRIPTION
Seems to give a noticeable improvement (most of the time is otherwise spent on optimisation of tensorflow graph rather than inference)